### PR TITLE
Define egg count numbers in parameter files instead of function `SetIntensityCount`

### DIFF
--- a/sth_simulation/data/AscarisParameters_high.txt
+++ b/sth_simulation/data/AscarisParameters_high.txt
@@ -46,4 +46,8 @@ k_epg	0.3
 ### Simulation-specific parameters
 nNodes	8	## number of cores, in practice is detected automatically on cluster 
 maxStep	0.01923	## max time step for deterministic update of freeliving populations, approx 1/52
-seed	123	## 
+seed	123	##
+
+### egg counts
+moderateIntensityCount	208.3
+highIntensityCount	2083.3

--- a/sth_simulation/data/AscarisParameters_moderate.txt
+++ b/sth_simulation/data/AscarisParameters_moderate.txt
@@ -24,7 +24,8 @@ gamma	0.07	Exponential density dependence of parasite adult stage (gamma) N.B. f
 
 ### Sexual reproduction styles. 
 reproFuncName	epgFertility	## name of function for reproduction (a string).  [Deterministic] 
-StochSR	TRUE		## Turn SR on or off in the stochastic model. 	[Stochastic]  
+StochSR	TRUE		## Turn SR on or off in the stochastic model. 	[Stochastic]
+unfertilized		TRUE
 
 ### Treatment parameters. 
 treatmentBreaks	0 2 5 15 70		Minimum age of each treatment group (minus sign necessary to include zero age): Infants; Pre-SAC; SAC; Adults
@@ -46,4 +47,8 @@ k_epg	0.3
 ### Simulation-specific parameters
 nNodes	8	## number of cores, in practice is detected automatically on cluster 
 maxStep	0.01923	## max time step for deterministic update of freeliving populations, approx 1/52
-seed	123	## 
+seed	123	##
+
+### egg counts
+moderateIntensityCount	208.3
+highIntensityCount	2083.3

--- a/sth_simulation/data/HookwormParameters_high.txt
+++ b/sth_simulation/data/HookwormParameters_high.txt
@@ -46,4 +46,8 @@ k_epg	0.35
 ### Simulation-specific parameters
 nNodes	8	## number of cores, in practice automatically set by cluster 
 maxStep	0.01923	## max time step for deterministic update of freeliving populations, approx 1/52
-seed	123	## 
+seed	123	##
+
+### egg counts
+moderateIntensityCount	83.3
+highIntensityCount	166.7

--- a/sth_simulation/data/HookwormParameters_moderate.txt
+++ b/sth_simulation/data/HookwormParameters_moderate.txt
@@ -46,4 +46,8 @@ k_epg	0.35
 ### Simulation-specific parameters
 nNodes	8	## number of cores, in practice automatically set by cluster 
 maxStep	0.01923	## max time step for deterministic update of freeliving populations, approx 1/52
-seed	123	## 
+seed	123	##
+
+### egg counts
+moderateIntensityCount	83.3
+highIntensityCount	166.7

--- a/sth_simulation/data/SCH_MansoniParameters.txt
+++ b/sth_simulation/data/SCH_MansoniParameters.txt
@@ -46,4 +46,8 @@ k_epg	0.87
 ### Simulation-specific parameters
 nNodes	8	## number of cores, in practice is detected automatically on cluster 
 maxStep	0.01923	## max time step for deterministic update of freeliving populations, approx 1/52
-seed	123	## 
+seed	123	##
+
+### egg counts
+moderateIntensityCount	4.2
+highIntensityCount	16.7

--- a/sth_simulation/data/TrichurisParameters_high.txt
+++ b/sth_simulation/data/TrichurisParameters_high.txt
@@ -46,4 +46,8 @@ k_epg	0.82
 ### Simulation-specific parameters
 nNodes	8	## number of cores, in practice detected by cluster
 maxStep	0.01923	## max time step for deterministic update of freeliving populations, approx 1/52
-seed	123	## 
+seed	123	##
+
+### egg counts
+moderateIntensityCount	41,7
+highIntensityCount	416.7

--- a/sth_simulation/data/TrichurisParameters_moderate.txt
+++ b/sth_simulation/data/TrichurisParameters_moderate.txt
@@ -46,4 +46,8 @@ k_epg	0.82
 ### Simulation-specific parameters
 nNodes	8	## number of cores, in practice detected by cluster
 maxStep	0.01923	## max time step for deterministic update of freeliving populations, approx 1/52
-seed	123	## 
+seed	123	##
+
+### egg counts
+moderateIntensityCount	41.7
+highIntensityCount	416.7

--- a/sth_simulation/helsim_FUNC.py
+++ b/sth_simulation/helsim_FUNC.py
@@ -5,53 +5,6 @@ import pkg_resources
 
 import sth_simulation.ParallelFuncs as ParallelFuncs
 
-def setIntensityCount(paramFileName):
-
-    '''
-    This function defines the intensity thresholds and converts them to egg counts.
-    Note that 24 is a conversion factor from epg (eggs per gram faeces) to egg counts
-    on a microscopy slide of a faecal smear test.
-
-    Ascaris: moderate intensity: 5,000, high intensity: 50,000.
-    Trichuris: moderate intensity: 1,000, high intensity: 10,000.
-    Hookworm: moderate intensity: 2,000, high intensity: 4,000.
-
-    Parameters
-    ----------
-    paramFileName: str
-        name of the input text file;
-
-    Returns
-    -------
-    moderateIntensityCount: float
-        moderate intensity threshold;
-
-    highIntensityCount: float
-        high intensity threshold;
-    '''
-
-    if paramFileName == 'AscarisParameters_moderate.txt' or paramFileName == 'AscarisParameters_high.txt':
-
-        moderateIntensityCount = 5000 / 24
-        highIntensityCount = 50000 / 24
-
-    elif paramFileName == 'TrichurisParameters_moderate.txt' or paramFileName == 'TrichurisParameters_high.txt':
-
-        moderateIntensityCount = 1000 / 24
-        highIntensityCount = 10000 / 24
-
-    elif paramFileName == 'HookwormParameters_moderate.txt' or paramFileName == 'HookwormParameters_high.txt':
-
-        moderateIntensityCount = 2000 / 24
-        highIntensityCount = 4000 / 24
-
-    elif paramFileName == 'SCH_MansoniParameters.txt' or paramFileName == 'SCH_HaematobiumParameters.txt':
-
-        moderateIntensityCount = 100 / 24
-        highIntensityCount = 400 / 24
-
-    return moderateIntensityCount, highIntensityCount
-
 def readParam(fileName):
 
     '''

--- a/sth_simulation/helsim_RUN.py
+++ b/sth_simulation/helsim_RUN.py
@@ -199,7 +199,6 @@ def STH_Simulation(paramFileName, demogName, MDAFilePath, PrevKKSACFilePath=None
                 parameters = configure(parameters)
                 parameters['psi'] = getPsi(parameters)
                 parameters['equiData'] = getEquilibrium(parameters)
-                parameters['moderateIntensityCount'], parameters['highIntensityCount'] = setIntensityCount(paramFileName)
 
                 # generate a simulation path
                 return doRealization(params=parameters, seed=seed[i])
@@ -239,7 +238,6 @@ def STH_Simulation(paramFileName, demogName, MDAFilePath, PrevKKSACFilePath=None
                 parameters = configure(parameters)
                 parameters['psi'] = getPsi(parameters)
                 parameters['equiData'] = getEquilibrium(parameters)
-                parameters['moderateIntensityCount'], parameters['highIntensityCount'] = setIntensityCount(paramFileName)
 
                 # add a simulation path
                 return addRealization(params=parameters, simData=simData, times=times, state=state)


### PR DESCRIPTION
The need for function `setIntensityCount` (`helsim_FUNC.py`) is currently unclear. This function returns a tuple `(highIntensityCount, moderateIntensityCount)` which values depend on the name of the parameter file:

```python
def setIntensityCount(...):
    # ...
    if paramFileName == 'AscarisParameters_moderate.txt' or paramFileName == 'AscarisParameters_high.txt':

        moderateIntensityCount = 5000 / 24
        highIntensityCount = 50000 / 24

    elif paramFileName == 'TrichurisParameters_moderate.txt' or paramFileName == 'TrichurisParameters_high.txt':

        moderateIntensityCount = 1000 / 24
        highIntensityCount = 10000 / 24

    # ...
    return moderateIntensityCount, highIntensityCount
```

it seems more natural and convenient to set these two numbers in the parameter files themselves:

```
...
### egg counts
moderateIntensityCount	208.3
highIntensityCount	2083.3
....
```

### Suggestion for further improvement

Maybe the reason for using `setIntensityCount` is to be able to set the "exact" value as a fraction instead of a approximate literal.
A solution would be to add the possiblity to mark lines that should be evaluated in Python, e.g.
```
...
### egg counts
moderateIntensityCount	[eval] 5000 / 24
highIntensityCount	[eval] 50000 / 24
....
```

then, when processing the file (likely in `readParam`):

```python
if parameter_string.startswith("[eval]"): # e.g. "[eval] 5000 / 24"
    parameter = eval(parameter_string(len("[eval]":).strip()) # e.g. eval("5000 / 24")
```


More generally, we would recommend using a well defined serialization language such as YAML for the parameter files. This would not solve the above issue, but would certainly make it easier to deal with. It would also make the parameter files easier to read and write, as well as more robust.

